### PR TITLE
Update all re-usable actions to their latest available SHAs

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,4 +16,4 @@ jobs:
     if: github.event.repository.private == false
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-dependency-review.yml@ba4afa056baf1ca2df3fa0f898404988bf6e7478 # v3.2.2
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-dependency-review.yml@cb9be5df20e49639fc617523d04b12059b266450 # v4.0.0

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -13,4 +13,4 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-release-container.yml@ba4afa056baf1ca2df3fa0f898404988bf6e7478 # v3.2.2
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-release-container.yml@cb9be5df20e49639fc617523d04b12059b266450 # v4.0.0

--- a/.github/workflows/scan-container.yml
+++ b/.github/workflows/scan-container.yml
@@ -14,6 +14,6 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@ba4afa056baf1ca2df3fa0f898404988bf6e7478 # v3.2.2
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@cb9be5df20e49639fc617523d04b12059b266450 # v4.0.0
     with:
       runtime: python

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -17,4 +17,4 @@ jobs:
       statuses: write
     with:
       super-linter-variables: '{"VALIDATE_PYTHON_RUFF_FORMAT": "false"}'
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@22e533bbaa3a26bfa2fc3715b74daeba79d6300a # v7.0.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@8465086d84a8ae8fb993ef582f00cf13b8ceb9c8 # v7.1.0

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -17,4 +17,4 @@ jobs:
       statuses: write
     with:
       super-linter-variables: '{"VALIDATE_PYTHON_RUFF_FORMAT": "false"}'
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@9e604949e842733e0990f5eb6627844e8715deeb # v6.4.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@22e533bbaa3a26bfa2fc3715b74daeba79d6300a # v7.0.0

--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -14,4 +14,4 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-test-container.yml@ba4afa056baf1ca2df3fa0f898404988bf6e7478 # v3.2.2
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-test-container.yml@cb9be5df20e49639fc617523d04b12059b266450 # v4.0.0


### PR DESCRIPTION
This PR is designed to be a clean example of how to update an Airflow Image to using the latest versions of our Github Actions. These feature breaking changes, details of which can be found in #ask-analytical-platform.