### PR TITLE
Add UV version vunerability to ignore file

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -4,3 +4,5 @@ AVD-DS-0002
 AVD-DS-0026
 # Temp skip for wheel vulnerability - to be fixed in future update
 CVE-2026-24049 exp:2026-02-06
+# Skip for UV vuln, to be fixed in base image update
+GHSA-82j2-j2ch-gfr8 exp:2026-05-15


### PR DESCRIPTION
This will allow me to unblock a number of dependabots until a base image update is available.