### PR TITLE
Update create-a-derived-table.sh

### DIFF
--- a/src/create-a-derived-table.sh
+++ b/src/create-a-derived-table.sh
@@ -20,6 +20,13 @@ export VARS="${VARS:-}"
 DEPLOY_ENV_UPPER=$(echo "${DEPLOY_ENV}" | tr '[:lower:]' '[:upper:]')
 export "DBT_${DEPLOY_ENV_UPPER}_PROFILE_WORKGROUP"="${DBT_PROFILE_WORKGROUP}"
 export DBT_PROFILE="${DBT_PROFILE:-"mojap"}"
+export SLEEP_BEFORE_RUN=30
+
+SLEEP_BEFORE_RUN="${SLEEP_BEFORE_RUN:-0}"
+if [ "${SLEEP_BEFORE_RUN}" -gt 0 ]; then
+  echo "Sleeping for ${SLEEP_BEFORE_RUN}s before running dbt..."
+  sleep "${SLEEP_BEFORE_RUN}"
+fi
 
 function run_dbt() {
   local max_retries=3


### PR DESCRIPTION
This pull request contributes to https://github.com/moj-analytical-services/de-ae-prisons/issues/769.

This pull request adds a configurable delay before running dbt in the `src/create-a-derived-table.sh` script. The main change is the introduction of the `SLEEP_BEFORE_RUN` environment variable, which allows users to specify a sleep duration before dbt execution.

Enhancements to dbt execution timing:

* Added the `SLEEP_BEFORE_RUN` environment variable (defaulting to 30 seconds) to control an optional delay before running dbt. If set to a value greater than 0, the script will sleep for that duration and print a message before proceeding.