### PR TITLE
Add functionality for DPR

### DIFF
--- a/src/create-a-derived-table.sh
+++ b/src/create-a-derived-table.sh
@@ -36,7 +36,7 @@ function run_dbt() {
   if [ -n "${THREAD_COUNT}" ]; then
     DBT_COMMAND+=(--threads "${THREAD_COUNT}")
   fi
-  if [ "${FULL_REFRESH}" = "true" ]; then
+  if [ "${FULL_REFRESH}" = "True" ]; then
     DBT_COMMAND+=(--full-refresh)
   fi
   if [ -n "${VARS}" ]; then
@@ -165,7 +165,7 @@ function import_run_artefacts() {
 }
 
 function enforce_lake_formation() {
-  if [ "${ENFORCE_LAKE_FORMATION}" = true ]; then
+  if [ "${ENFORCE_LAKE_FORMATION}" = "True" ]; then
     echo "Enforcing lake formation permissions"
     python "${REPOSITORY_PATH}/scripts/enforce_lake_formation.py"
     return 0
@@ -227,7 +227,7 @@ if $STATE_MODE; then
   export DBT_SELECT_CRITERIA="{$DBT_SELECT_CRITERIA},state:modified"
 fi
 
-if [ "$RUN_SOURCE_FRESHNESS" = true ]; then
+if [ "$RUN_SOURCE_FRESHNESS" = "True" ]; then
   run_source_freshness
 fi
 

--- a/src/create-a-derived-table.sh
+++ b/src/create-a-derived-table.sh
@@ -25,7 +25,6 @@ export RUN_SOURCE_FRESHNESS="${RUN_SOURCE_FRESHNESS:-false}"
 export FULL_REFRESH="${FULL_REFRESH:-false}"
 
 function run_dbt() {
-  local full_refresh="${1:-}"
   local max_retries=3
   local attempt=2
   local previous_attempt=1

--- a/src/create-a-derived-table.sh
+++ b/src/create-a-derived-table.sh
@@ -20,8 +20,12 @@ export VARS="${VARS:-}"
 DEPLOY_ENV_UPPER=$(echo "${DEPLOY_ENV}" | tr '[:lower:]' '[:upper:]')
 export "DBT_${DEPLOY_ENV_UPPER}_PROFILE_WORKGROUP"="${DBT_PROFILE_WORKGROUP}"
 export DBT_PROFILE="${DBT_PROFILE:-"mojap"}"
+export ENFORCE_LAKE_FORMATION="${ENFORCE_LAKE_FORMATION:-false}"
+export RUN_SOURCE_FRESHNESS="${RUN_SOURCE_FRESHNESS:-false}"
+export FULL_REFRESH="${FULL_REFRESH:-false}"
 
 function run_dbt() {
+  local full_refresh="${1:-}"
   local max_retries=3
   local attempt=2
   local previous_attempt=1
@@ -32,6 +36,9 @@ function run_dbt() {
   local -a DBT_COMMAND=(dbt "${MODE}" --profiles-dir "${REPOSITORY_PATH}/.dbt" --select "${DBT_SELECT_CRITERIA}" --target "${DEPLOY_ENV}")
   if [ -n "${THREAD_COUNT}" ]; then
     DBT_COMMAND+=(--threads "${THREAD_COUNT}")
+  fi
+  if [ "${FULL_REFRESH}" = "true" ]; then
+    DBT_COMMAND+=(--full-refresh)
   fi
   if [ -n "${VARS}" ]; then
     DBT_COMMAND+=(--vars "${VARS}")
@@ -77,14 +84,20 @@ function run_dbt() {
   set -e # Re-enable immediate exit on error
 }
 
-function nomis_setup() {
-  echo "Running NOMIS specific setup"
+function run_source_freshness() {
+  local source="${1:-}"
   local max_retries=5
   local attempt=2
   set +e
-  local -a DBT_COMMAND=(dbt source freshness --target "${DEPLOY_ENV}" --select source:nomis_unixtime)
+
+  local -a DBT_COMMAND
+  if [ -n "${source}" ]; then
+    DBT_COMMAND=(dbt source freshness --target "${DEPLOY_ENV}" --select "source:${source}")
+  else
+    DBT_COMMAND=(dbt source freshness --target "${DEPLOY_ENV}")
+  fi
   if "${DBT_COMMAND[@]}"; then
-    echo "NOMIS source freshness check passed"
+    echo "Source freshness check passed"
     rm -f "${REPOSITORY_PATH}/${DBT_PROJECT}/target/run_results.json"
   elif [ -f "${REPOSITORY_PATH}/${DBT_PROJECT}/target/run_results.json" ]; then
     echo "NOMIS source freshness check failed on freshness, exiting."
@@ -113,6 +126,11 @@ function nomis_setup() {
       fi
     done
   fi
+}
+
+function nomis_setup() {
+  echo "Running NOMIS specific setup"
+  run_source_freshness "nomis_unixtime"
   python "${REPOSITORY_PATH}/scripts/generate_partition_queries.py" "${REPOSITORY_PATH}/${DBT_PROJECT}/model_templates/" "${REPOSITORY_PATH}/${DBT_PROJECT}" --target "${DEPLOY_ENV}" --source "nomis"
   dbt run-operation check_if_models_exist_by_tag \
     --args '{"tag_names":["dual_materialization","nomis_daily"], "tag_mode":"intersect"}' \
@@ -145,6 +163,16 @@ function import_run_artefacts() {
   export ARTEFACT_TARGET
 
   python "${REPOSITORY_PATH}/scripts/import_run_artefacts.py" --target "$ARTEFACT_TARGET"
+}
+
+function enforce_lake_formation() {
+  if [ "${ENFORCE_LAKE_FORMATION}" = true ]; then
+    echo "Enforcing lake formation permissions"
+    python "${REPOSITORY_PATH}/scripts/enforce_lake_formation.py"
+    return 0
+  else
+    return 0
+  fi
 }
 
 echo "Creating virtual environment and installing dependencies"
@@ -200,6 +228,10 @@ if $STATE_MODE; then
   export DBT_SELECT_CRITERIA="{$DBT_SELECT_CRITERIA},state:modified"
 fi
 
+if [ "$RUN_SOURCE_FRESHNESS" = true ]; then
+  run_source_freshness
+fi
+
 if [ "$WORKFLOW_NAME" = "nomis-daily" ]; then
   nomis_setup
 fi
@@ -207,6 +239,7 @@ fi
 if run_dbt; then
   echo "dbt run (partially) succeeded"
   echo "Exporting run artefacts"
+  enforce_lake_formation
   export_run_artefacts
   exit 0
 else

--- a/src/create-a-derived-table.sh
+++ b/src/create-a-derived-table.sh
@@ -99,26 +99,26 @@ function run_source_freshness() {
     echo "Source freshness check passed"
     rm -f "${REPOSITORY_PATH}/${DBT_PROJECT}/target/run_results.json"
   elif [ -f "${REPOSITORY_PATH}/${DBT_PROJECT}/target/run_results.json" ]; then
-    echo "NOMIS source freshness check failed on freshness, exiting."
+    echo "Source freshness check failed on freshness, exiting."
     return 1
   else
-    echo "NOMIS source freshness check failed without running, retrying."
+    echo "Source freshness check failed without running, retrying."
     while [[ "${attempt}" -le "${max_retries}" ]]; do
       echo "Attempt ${attempt} of ${max_retries} to run NOMIS source freshness check"
       if [[ "${attempt}" -eq "${max_retries}" ]]; then
-        echo "NOMIS source freshness check failed after ${max_retries} attempts, exiting."
+        echo "Source freshness check failed after ${max_retries} attempts, exiting."
         return 1
       else
-        echo "NOMIS source freshness check failed on attempt ${attempt}, retrying"
+        echo "Source freshness check failed on attempt ${attempt}, retrying"
         if "${DBT_COMMAND[@]}"; then
-          echo "NOMIS source freshness check passed on retry"
+          echo "Source freshness check passed on retry"
           rm -f "${REPOSITORY_PATH}/${DBT_PROJECT}/target/run_results.json"
           return 0
         elif [ -f "${REPOSITORY_PATH}/${DBT_PROJECT}/target/run_results.json" ]; then
-          echo "NOMIS source freshness check failed on freshness, exiting."
+          echo "Source freshness check failed on freshness, exiting."
           return 1
         else
-          echo "NOMIS source freshness check failed on attempt ${attempt} without running, retrying."
+          echo "Source freshness check failed on attempt ${attempt} without running, retrying."
         fi
         ((attempt++))
         sleep 10 # Wait before retrying

--- a/src/create-a-derived-table.sh
+++ b/src/create-a-derived-table.sh
@@ -23,6 +23,7 @@ export DBT_PROFILE="${DBT_PROFILE:-"mojap"}"
 export ENFORCE_LAKE_FORMATION="${ENFORCE_LAKE_FORMATION:-false}"
 export RUN_SOURCE_FRESHNESS="${RUN_SOURCE_FRESHNESS:-false}"
 export FULL_REFRESH="${FULL_REFRESH:-false}"
+export RUN_UNIT_TESTS="${RUN_UNIT_TESTS:-false}"
 
 function run_dbt() {
   local max_retries=3
@@ -174,6 +175,16 @@ function enforce_lake_formation() {
   fi
 }
 
+function run_unit_tests() {
+  if [ "${RUN_UNIT_TESTS}" = "True" ]; then
+    echo "Running unit tests"
+    dbt test -s test_type:unit --target "${DEPLOY_ENV}"
+    return 0
+  else
+    return 0
+  fi
+}
+
 echo "Creating virtual environment and installing dependencies"
 cd "${REPOSITORY_PATH}"
 
@@ -234,6 +245,8 @@ fi
 if [ "$WORKFLOW_NAME" = "nomis-daily" ]; then
   nomis_setup
 fi
+
+run_unit_tests
 
 if run_dbt; then
   echo "dbt run (partially) succeeded"


### PR DESCRIPTION

This pull request enhances the `src/create-a-derived-table.sh` script by adding new environment variable controls and modularizing key workflow steps. The changes improve configurability and make it easier to enable or disable features like source freshness checks, full refreshes, unit tests, and lake formation enforcement.

**New feature flags and environment variables:**

* Added new environment variables: `ENFORCE_LAKE_FORMATION`, `RUN_SOURCE_FRESHNESS`, `FULL_REFRESH`, and `RUN_UNIT_TESTS`, all defaulting to `false`. These allow toggling related features without code changes.

**Workflow modularization and enhancements:**

* Refactored the source freshness check into a generic `run_source_freshness` function (replacing the NOMIS-specific version), allowing it to be called with an optional source argument and reused elsewhere.
* Added a `run_unit_tests` function to conditionally execute dbt unit tests if enabled via the environment variable.
* Added an `enforce_lake_formation` function to conditionally enforce lake formation permissions after a successful dbt run.

**Integration of feature flags into workflow:**

* Updated the main workflow to call `run_source_freshness`, `run_unit_tests`, and `enforce_lake_formation` at appropriate steps, controlled by their respective environment variables.
* Modified the dbt run command to include the `--full-refresh` flag when `FULL_REFRESH` is enabled.