### PR TITLE
Prisons - add export for dual materialization check

### DIFF
--- a/src/create-a-derived-table.sh
+++ b/src/create-a-derived-table.sh
@@ -186,6 +186,23 @@ function run_unit_tests() {
   fi
 }
 
+function set_dual_materialization_env_vars() {
+  if [ "$CHECK_DUAL_MATERIALIZATION" = "True" ]; then
+    echo "Checking for models with dual materialization config"
+
+    while IFS= read -r variable; do
+      export "$variable"
+      echo "Added: $variable"
+    done < <(
+      dbt run-operation check_if_models_exist_by_tag \
+        --args '{"tag_names":["dual_materialization"], "tag_mode":"intersect"}' \
+        --target "$DEPLOY_ENV" \
+      | grep "|model_check|" \
+      | sed 's/.*|model_check|//'
+    )
+  fi
+}
+
 echo "Creating virtual environment and installing dependencies"
 cd "${REPOSITORY_PATH}"
 
@@ -231,6 +248,10 @@ dbt clean
 
 echo "Running dbt deps"
 dbt deps
+
+if [ "$CHECK_DUAL_MATERIALIZATION" = "True" ]; then
+  set_dual_materialization_env_vars
+fi
 
 echo "Running in mode [ ${MODE} ] for project [ ${DBT_PROJECT} ] to environment [ ${DEPLOY_ENV} ] with select criteria [ ${DBT_SELECT_CRITERIA} ] and thread count [ ${THREAD_COUNT} ] and vars [ ${VARS:-none} ]"
 

--- a/src/create-a-derived-table.sh
+++ b/src/create-a-derived-table.sh
@@ -24,6 +24,7 @@ export ENFORCE_LAKE_FORMATION="${ENFORCE_LAKE_FORMATION:-false}"
 export RUN_SOURCE_FRESHNESS="${RUN_SOURCE_FRESHNESS:-false}"
 export FULL_REFRESH="${FULL_REFRESH:-false}"
 export RUN_UNIT_TESTS="${RUN_UNIT_TESTS:-false}"
+export CHECK_DUAL_MATERIALIZATION="${CHECK_DUAL_MATERIALIZATION:-false}"
 
 function run_dbt() {
   local max_retries=3


### PR DESCRIPTION
Adding functionality to replicate [this](https://github.com/moj-analytical-services/create-a-derived-table/blob/ba6ef8f75bdf0c47c6fdbc27072a18d37f737e5f/.github/workflows/data-factory-template-workflow.yml#L209-L218)


We can now optionally run a dbt operation and export some environment variables. Default is False