### PR TITLE
updated check run results

### DIFF
--- a/src/check_run_results.py
+++ b/src/check_run_results.py
@@ -18,6 +18,8 @@ DEFAULT_UNIQUE_ID_YAML = Path(
     "./create-a-derived-table/scripts/data/airflow-dag-trigger.yaml"
 )
 
+DEFAULT_S3_BUCKET = "mojap-derived-tables"
+
 # dbt models finish with 'success'; tests finish with 'pass' or 'warn'.
 # All three are considered acceptable (non-failure) statuses.
 _ACCEPTABLE_STATUSES = frozenset({"success", "pass", "warn"})
@@ -119,10 +121,13 @@ def _load_run_results(path: Path) -> tuple[dict, str]:
 def _download_run_results_from_s3(
     deploy_env: str,
     workflow_name: str,
-    bucket: str = "mojap-derived-tables",
+    bucket: str,
 ) -> list[dict]:
     """Download run_results files from S3 and return parsed JSON objects."""
-    prefix = f"{deploy_env}/run_artefacts/{workflow_name}/latest/target/"
+    if bucket == DEFAULT_S3_BUCKET:
+        prefix = f"{deploy_env}/run_artefacts/{workflow_name}/latest/target/"
+    else:
+        prefix = f"data/{deploy_env}/run_artefacts/{workflow_name}/latest/target/"
     client = boto3.client("s3")
     paginator = client.get_paginator("list_objects_v2")
     keys: list[str] = []
@@ -168,6 +173,7 @@ def _index_statuses(run_results: dict) -> dict[str, str]:
 
 def assert_success(
     unique_ids: Iterable[str],
+    bucket: str,
     deploy_env: str | None = None,
     workflow_name: str | None = None,
 ) -> None:
@@ -179,7 +185,8 @@ def assert_success(
         raise ValueError(
             "DEPLOY_ENV and WORKFLOW_NAME are required to locate run_results files."
         )
-    run_results_list = _download_run_results_from_s3(deploy_env, workflow_name)
+
+    run_results_list = _download_run_results_from_s3(deploy_env, workflow_name, bucket)
 
     for run_results in run_results_list:
         statuses = _index_statuses(run_results)
@@ -216,6 +223,7 @@ def assert_success(
 
 
 def assert_all_models_tests_success(
+    bucket: str,
     deploy_env: str | None = None,
     workflow_name: str | None = None,
 ) -> None:
@@ -224,7 +232,8 @@ def assert_all_models_tests_success(
         raise ValueError(
             "DEPLOY_ENV and WORKFLOW_NAME are required to locate run_results files."
         )
-    run_results_list = _download_run_results_from_s3(deploy_env, workflow_name)
+
+    run_results_list = _download_run_results_from_s3(deploy_env, workflow_name, bucket)
 
     # Build the final status for each model/test node across all run_results
     # files (later files override earlier ones, matching retry semantics).
@@ -314,15 +323,18 @@ def main() -> int:
 
     deploy_env = os.environ.get("DEPLOY_ENV")
     workflow_name = os.environ.get("WORKFLOW_NAME")
+    bucket = os.environ.get("S3_BUCKET") or DEFAULT_S3_BUCKET
     logging.info(
-        "Loaded env DEPLOY_ENV=%s WORKFLOW_NAME=%s",
+        "Loaded env DEPLOY_ENV=%s WORKFLOW_NAME=%s S3_BUCKET=%s",
         deploy_env,
         workflow_name,
+        bucket,
     )
 
     if args.check_all_nodes:
         logging.info("CHECK_ALL_NODES is enabled - validating all model and test nodes")
         assert_all_models_tests_success(
+            bucket=bucket,
             deploy_env=deploy_env,
             workflow_name=workflow_name,
         )
@@ -359,6 +371,7 @@ def main() -> int:
     logging.info("Beginning run_results validation")
     assert_success(
         unique_ids,
+        bucket=bucket,
         deploy_env=deploy_env,
         workflow_name=workflow_name,
     )


### PR DESCRIPTION
https://github.com/orgs/moj-analytical-services/projects/101/views/11?filterQuery=repo%3A%22moj-analytical-services%2Fdmet-probation%22%2C%22ministryofjustice%2Fanalytical-platform-data-engineering%22+label%3Adata-engineering&pane=issue&itemId=220812993&issue=moj-analytical-services%7Cdmet-probation%7C276

This pull request updates the `src/check_run_results.py` script to add support for specifying a custom S3 bucket from which to download `run_results` files, rather than always using the default bucket. The bucket can now be provided via the `S3_BUCKET` environment variable, and the relevant functions have been updated to accept and use this parameter.

**S3 Bucket Selection and Usage:**

* Introduced a new constant `DEFAULT_S3_BUCKET` and logic to select the S3 bucket using the `S3_BUCKET` environment variable or default to `"mojap-derived-tables"` if not set. (`src/check_run_results.py`) [[1]](diffhunk://#diff-ae4523e7c5605297dcef52228a0415e49feb3ef81da2fd1c6cbcd0f66349a093R21-R22) [[2]](diffhunk://#diff-ae4523e7c5605297dcef52228a0415e49feb3ef81da2fd1c6cbcd0f66349a093R326-R337)
* Updated the `_download_run_results_from_s3` function to accept a `bucket` parameter and adjust the S3 prefix depending on whether the default or a custom bucket is used. (`src/check_run_results.py`)
* Modified `assert_success` and `assert_all_models_tests_success` to require and propagate the `bucket` parameter, ensuring all S3 interactions use the correct bucket. (`src/check_run_results.py`) [[1]](diffhunk://#diff-ae4523e7c5605297dcef52228a0415e49feb3ef81da2fd1c6cbcd0f66349a093R176) [[2]](diffhunk://#diff-ae4523e7c5605297dcef52228a0415e49feb3ef81da2fd1c6cbcd0f66349a093L182-R189) [[3]](diffhunk://#diff-ae4523e7c5605297dcef52228a0415e49feb3ef81da2fd1c6cbcd0f66349a093R226) [[4]](diffhunk://#diff-ae4523e7c5605297dcef52228a0415e49feb3ef81da2fd1c6cbcd0f66349a093L227-R236)
* Updated the `main` function to read the bucket from the environment and pass it to all relevant function calls, and improved logging to include the bucket name. (`src/check_run_results.py`) [[1]](diffhunk://#diff-ae4523e7c5605297dcef52228a0415e49feb3ef81da2fd1c6cbcd0f66349a093R326-R337) [[2]](diffhunk://#diff-ae4523e7c5605297dcef52228a0415e49feb3ef81da2fd1c6cbcd0f66349a093R374)